### PR TITLE
added exception for hash rockets in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,8 @@ RedundantReturn:
 #   and it will likely require building of over-length lines.
 IfUnlessModifier:
   Enabled: false
+
+# Don't complain about older hash rocket hash syntax. This was causing
+#   problems when configuring things like 'supports' for resources.
+HashSyntax:
+  EnforcedStyle: hash_rockets


### PR DESCRIPTION
This will stop rubocop from complaining about the hash rockets in resources/templates (such as supports, example below):

```
user "zack" do
  shell node[:rackspace_user][:users]["#{user}"][:shell]
  home node[:rackspace_user][:users]["#{user}"][:home]
  comment node[:rackspace_user][:users]["#{user}"][:note]
  supports :manage_home => false
  action :create
end
```

^ On the 'supports' line - it was complaining that I should use the newer Ruby 1.9 syntax. Trying to use the new Ruby 1.9 syntax caused further errors/ugliness. Worked with Tom on this - we both thing ignoring this is much more legible and logical. Thoughts?
