### PR TITLE
upped threshold for cyclomaticcomplexity to 10

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,7 @@ RedundantReturn:
 #   and it will likely require building of over-length lines.
 IfUnlessModifier:
   Enabled: false
+
+# Raise allowed CyclomaticComplexity to 10.
+CyclomaticComplexity:
+  Max: 10


### PR DESCRIPTION
Increased threshold for CyclomaticComplexity in rubocop to 10. We've hit this several times now - the work required to redo them outweighs the benefits. 
