### PR TITLE
Added cookbook path to Rubocop to only check the current cookbook

### DIFF
--- a/Strainerfile
+++ b/Strainerfile
@@ -1,6 +1,9 @@
 # Strainerfile
 knife_test: bundle exec knife cookbook test $COOKBOOK -o $SANDBOX -z
-rubocop:    bundle exec rubocop --no-color
+
+# Rubocop needs to be passed $SANDBOX/$COOKBOOK or else it will check all the cookbook
+#   dependencies populated by Berkshelf as well.
+rubocop:    bundle exec rubocop --no-color $SANDBOX/$COOKBOOK
 foodcritic: bundle exec foodcritic -f any $SANDBOX/$COOKBOOK
 chefspec:   bundle exec rspec
 kitchen:    bundle exec kitchen test --destroy always


### PR DESCRIPTION
Without a cookbook path passed to Rubocop it will run in the temp directory which is populated with all the dependency cookbooks by Berkshelf.  This can cause the Strainer strin to fail due to style errors in other cookbooks, which is not exactly desirable.  This makes it more better.
