### PR TITLE
Switch from Strainer to Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,4 @@
 #
-# Cookbook Name:: rackspace_cloudmonitoring
-#
 # Copyright 2014, Rackspace, US, Inc.
 # Copyright 2013-2014 Chef Software, Inc.
 # Copyright 2011 Fletcher Nichol

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,65 @@
+#
+# Cookbook Name:: rackspace_cloudmonitoring
+#
+# Copyright 2014, Rackspace, US, Inc.
+# Copyright 2013-2014 Chef Software, Inc.
+# Copyright 2011 Fletcher Nichol
+# Copyright 2010 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Originally from https://github.com/opscode-cookbooks/jenkins/blob/master/Rakefile
+#
+# Tasks can be called individually: bundle exec rake style_unit
+
+require 'bundler/setup'
+
+namespace :style do
+  require 'rubocop/rake_task'
+  desc 'Run Ruby style checks'
+  Rubocop::RakeTask.new(:ruby)
+
+  require 'foodcritic'
+  desc 'Run Chef style checks'
+  FoodCritic::Rake::LintTask.new(:chef) { |task| 
+    task.options = { fail_tags: ['any'] }
+  }
+end
+
+desc 'Run all style checks'
+task style: ['style:chef', 'style:ruby']
+
+require 'rspec/core/rake_task'
+desc 'Run RSpec and ChefSpec unit tests'
+RSpec::Core::RakeTask.new(:unit)
+
+desc 'Run style and unit tests'
+task style_unit: ['style:chef', 'style:ruby', 'unit']
+
+require 'kitchen'
+desc 'Run Test Kitchen integration tests'
+task :integration do
+  Kitchen.logger = Kitchen.default_file_logger
+  Kitchen::Config.new.instances.each do |instance|
+    instance.test(:always)
+  end
+end
+
+# We cannot run Test Kitchen on Travis CI yet...
+namespace :travis do
+  desc 'Run tests on Travis'
+  task ci: ['style']
+end
+
+# The default rake task should just run it all
+task default: ['style', 'unit', 'integration']

--- a/Strainerfile
+++ b/Strainerfile
@@ -1,9 +1,0 @@
-# Strainerfile
-knife_test: bundle exec knife cookbook test $COOKBOOK -o $SANDBOX -z
-
-# Rubocop needs to be passed $SANDBOX/$COOKBOOK or else it will check all the cookbook
-#   dependencies populated by Berkshelf as well.
-rubocop:    bundle exec rubocop --no-color $SANDBOX/$COOKBOOK
-foodcritic: bundle exec foodcritic -f any $SANDBOX/$COOKBOOK
-chefspec:   bundle exec rspec
-kitchen:    bundle exec kitchen test --destroy always


### PR DESCRIPTION
Per my conversation with SethVargo strainer is planned for deprecation, and we're having cleanup issues due to https://github.com/customink/strainer/issues/53

This pull changes from a Strainerfile to a Rakefile, with the exception of knife_test it executes the same tests as the Strainerfile.
