### PR TITLE
Newer rubocop wants Rakefile changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :testing do
   gem 'strainer',   '~> 3.3'
   gem 'chef',       '~> 11.8'
   gem 'rspec',      '~> 2.14'
-  gem 'rubocop',    '~> 0.18.0' 
+  gem 'rubocop',    '~> 0.21.0' 
   gem 'rake',       '~> 10.1'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,20 +29,20 @@ namespace :style do
 
   require 'foodcritic'
   desc 'Run Chef style checks'
-  FoodCritic::Rake::LintTask.new(:chef) { |task| 
+  FoodCritic::Rake::LintTask.new(:chef) do |task|
     task.options = { fail_tags: ['any'] }
-  }
+  end
 end
 
 desc 'Run all style checks'
-task style: ['style:chef', 'style:ruby']
+task style: %w(style:chef style:ruby)
 
 require 'rspec/core/rake_task'
 desc 'Run RSpec and ChefSpec unit tests'
 RSpec::Core::RakeTask.new(:unit)
 
 desc 'Run style and unit tests'
-task style_unit: ['style:chef', 'style:ruby', 'unit']
+task style_unit: %w(style:chef style:ruby unit)
 
 require 'kitchen'
 desc 'Run Test Kitchen integration tests'
@@ -56,8 +56,8 @@ end
 # We cannot run Test Kitchen on Travis CI yet...
 namespace :travis do
   desc 'Run tests on Travis'
-  task ci: ['style']
+  task ci: %w(style)
 end
 
 # The default rake task should just run it all
-task default: ['style', 'unit', 'integration']
+task default: %w(style unit integration)


### PR DESCRIPTION
After going to a newer rubocop (0.21.0), it complains about our standard Rakefile:

```
$ bundle exec rake style
Running RuboCop...
Inspecting 1 file
C

Offenses:

Rakefile:32:41: C: Avoid using {...} for multi-line blocks.
  FoodCritic::Rake::LintTask.new(:chef) { |task| 
                                        ^
Rakefile:32:49: C: Trailing whitespace detected.
  FoodCritic::Rake::LintTask.new(:chef) { |task| 
                                                ^
Rakefile:63:15: C: Use %w or %W for array of words.
task default: ['style', 'unit', 'integration']
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 3 offenses detected
RuboCop failed!
```

I bumped the version and fixed the complaints in this commit.

```
$ bundle exec rake style
Running RuboCop...
Inspecting 1 file
.

1 file inspected, no offenses detected
```

Thanks!
Martin
